### PR TITLE
Add auto-refresh scheduler for dashboard with configurable cron schedule

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ GITHUB_TOKEN=ghp_your_token_here
 # Auto-seed on first startup (comma-separated for multiple)
 GH_MONIT_USER=your-username
 # GH_MONIT_ORG=your-org
+
+# Auto-refresh schedule (cron expression, default: daily at 6:00 AM)
+# GH_MONIT_REFRESH_SCHEDULE=0 6 * * *

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ CLI and dashboard to fetch and monitor Dependabot alerts for GitHub repositories
 - Output results in readable text format or JSON for integration with other tools.
 - Support for including forked repositories.
 - Web dashboard with trend charts, MTTR metrics, SLA tracking, and cross-repo analytics.
+- Automatic daily refresh of all tracked repos via built-in cron scheduler.
 - Docker-ready for server deployment.
 
 ## Authentication
@@ -177,6 +178,32 @@ docker run -d \
 | `GH_MONIT_USER` | GitHub username(s) to auto-seed on first startup (comma-separated) | — |
 | `GH_MONIT_ORG` | GitHub org(s) to auto-seed on first startup (comma-separated) | — |
 | `GH_MONIT_DB_PATH` | Path to the SQLite database file | `/data/gh-monit.db` (Docker) or `~/.gh-monit/gh-monit.db` (local) |
+| `GH_MONIT_REFRESH_SCHEDULE` | Cron expression for auto-refresh schedule | `0 6 * * *` (daily at 6:00 AM) |
+
+### Auto-refresh scheduler
+
+The dashboard includes a built-in cron scheduler that automatically refreshes all tracked repos on a configurable schedule. By default, it runs daily at 6:00 AM.
+
+Configure the schedule via the `GH_MONIT_REFRESH_SCHEDULE` environment variable using standard cron syntax:
+
+```bash
+# Every 6 hours
+GH_MONIT_REFRESH_SCHEDULE="0 */6 * * *"
+
+# Twice daily at 8am and 8pm
+GH_MONIT_REFRESH_SCHEDULE="0 8,20 * * *"
+
+# Every Monday at midnight
+GH_MONIT_REFRESH_SCHEDULE="0 0 * * 1"
+```
+
+The scheduler staggers API calls with a 2-second delay between repos to stay within GitHub rate limits. If a refresh cycle is still running when the next one is scheduled, it will be skipped.
+
+Check the scheduler status via the API:
+
+```bash
+curl http://localhost:3847/api/scheduler
+```
 
 ## How it Works
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - GITHUB_TOKEN=${GITHUB_TOKEN}
       - GH_MONIT_USER=${GH_MONIT_USER:-}
       - GH_MONIT_ORG=${GH_MONIT_ORG:-}
+      - GH_MONIT_REFRESH_SCHEDULE=${GH_MONIT_REFRESH_SCHEDULE:-0 6 * * *}
     volumes:
       - gh-monit-data:/data
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "chalk": "^5.6.2",
         "commander": "^14.0.3",
         "hono": "^4.11.9",
+        "node-cron": "^4.2.1",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -23,6 +24,7 @@
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.2.3",
+        "@types/node-cron": "^3.0.11",
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
@@ -1054,6 +1056,13 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1621,6 +1630,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "hono": "^4.11.9",
+    "node-cron": "^4.2.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.2.3",
+    "@types/node-cron": "^3.0.11",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -1,0 +1,178 @@
+import cron from 'node-cron';
+import type Database from 'better-sqlite3';
+import type { Octokit } from '@octokit/rest';
+import chalk from 'chalk';
+import { getAllRepoSummaries, saveAlerts } from './db.js';
+import { normalizeAlerts } from './alerts.js';
+import { fetchDependabotAlerts } from './github.js';
+
+export type RefreshResult = {
+  refreshed: number;
+  failed: number;
+  total: number;
+  results: { repo: string; success: boolean }[];
+};
+
+export type SchedulerState = {
+  running: boolean;
+  lastRun: string | null;
+  lastResult: Omit<RefreshResult, 'results'> | null;
+  nextRun: string | null;
+  cronExpression: string;
+};
+
+const STAGGER_DELAY_MS = 2000;
+
+let state: SchedulerState = {
+  running: false,
+  lastRun: null,
+  lastResult: null,
+  nextRun: null,
+  cronExpression: '',
+};
+
+let task: cron.ScheduledTask | null = null;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getNextRunDate(expression: string): string | null {
+  try {
+    const interval = cron.getTasks();
+    const now = new Date();
+    const parts = expression.split(' ');
+    if (parts.length !== 5) return null;
+
+    const [minute, hour] = parts;
+    const next = new Date(now);
+
+    const targetHour = hour === '*' ? now.getHours() : Number(hour);
+    const targetMinute = minute === '*' ? now.getMinutes() : Number(minute);
+
+    next.setHours(targetHour, targetMinute, 0, 0);
+    if (next <= now) {
+      next.setDate(next.getDate() + 1);
+    }
+
+    return next.toISOString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Refreshes all tracked repos sequentially with a staggered delay.
+ * Shared by the cron scheduler and the manual refresh-all endpoint.
+ */
+export async function refreshAllRepos(
+  db: Database.Database,
+  octokit: Octokit
+): Promise<RefreshResult> {
+  const repos = getAllRepoSummaries(db);
+  const results: { repo: string; success: boolean }[] = [];
+
+  for (let i = 0; i < repos.length; i++) {
+    const { repo } = repos[i];
+    const [owner, name] = repo.split('/');
+
+    try {
+      const raw = await fetchDependabotAlerts(octokit, {
+        owner,
+        name,
+        fullName: repo,
+      });
+      if (raw) {
+        const alerts = normalizeAlerts(repo, raw);
+        saveAlerts(db, repo, alerts, new Date().toISOString());
+        results.push({ repo, success: true });
+      } else {
+        results.push({ repo, success: false });
+      }
+    } catch {
+      results.push({ repo, success: false });
+    }
+
+    if (i < repos.length - 1) {
+      await delay(STAGGER_DELAY_MS);
+    }
+  }
+
+  const refreshed = results.filter((r) => r.success).length;
+  const failed = results.filter((r) => !r.success).length;
+
+  return { refreshed, failed, total: repos.length, results };
+}
+
+export function getSchedulerStatus(): SchedulerState {
+  return { ...state };
+}
+
+/**
+ * Starts the cron scheduler that periodically refreshes all tracked repos.
+ * Returns the initial scheduler state. Only one scheduler can run at a time.
+ */
+export function startScheduler(
+  db: Database.Database,
+  octokit: Octokit,
+  cronExpression: string
+): SchedulerState {
+  if (task) {
+    task.stop();
+  }
+
+  state = {
+    running: false,
+    lastRun: null,
+    lastResult: null,
+    nextRun: getNextRunDate(cronExpression),
+    cronExpression,
+  };
+
+  task = cron.schedule(cronExpression, async () => {
+    if (state.running) {
+      console.log(
+        chalk.yellow('  Scheduler: skipping run — previous refresh still in progress')
+      );
+      return;
+    }
+
+    state.running = true;
+    const startTime = new Date();
+    console.log(
+      chalk.cyan(`  Scheduler: starting auto-refresh at ${startTime.toISOString()}`)
+    );
+
+    try {
+      const result = await refreshAllRepos(db, octokit);
+      state.lastRun = startTime.toISOString();
+      state.lastResult = {
+        refreshed: result.refreshed,
+        failed: result.failed,
+        total: result.total,
+      };
+      state.nextRun = getNextRunDate(cronExpression);
+
+      console.log(
+        chalk.green(
+          `  Scheduler: refresh complete — ${result.refreshed}/${result.total} repos updated` +
+            (result.failed > 0 ? `, ${result.failed} failed` : '')
+        )
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(chalk.red(`  Scheduler: refresh failed — ${message}`));
+    } finally {
+      state.running = false;
+    }
+  });
+
+  return { ...state };
+}
+
+export function stopScheduler(): void {
+  if (task) {
+    task.stop();
+    task = null;
+  }
+}


### PR DESCRIPTION
Introduces an in-process cron scheduler (node-cron) that automatically
refreshes all tracked repos on a configurable schedule (default: daily
at 6 AM). Extracts refresh logic into a shared refreshAllRepos() to
eliminate duplication between the scheduler, the refresh-all endpoint,
and future consumers. Includes staggered API calls (2s delay), overlap
guard, and a GET /api/scheduler status endpoint.
