### PR TITLE
feat: add test suite with Vitest (58 tests)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,42 @@
         "@types/node-cron": "^3.0.11",
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -533,6 +568,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@octokit/auth-token": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
@@ -547,7 +599,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -688,6 +739,278 @@
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
       }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
+      "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1039,6 +1362,24 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -1048,6 +1389,24 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1073,6 +1432,119 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
+      "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
+      "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
+      "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
+      "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.1",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
+      "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
+      "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
+      "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1092,6 +1564,16 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1203,6 +1685,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -1262,6 +1754,13 @@
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1323,6 +1822,13 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
@@ -1330,7 +1836,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1366,6 +1871,16 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1373,6 +1888,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-content-type-parse": {
@@ -1472,7 +1997,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1524,6 +2048,267 @@
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.7.tgz",
       "integrity": "sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==",
       "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -1624,6 +2409,25 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -1661,6 +2465,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1690,7 +2505,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1718,6 +2532,35 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-load-config": {
@@ -1863,6 +2706,40 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
+      "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.11"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -1940,6 +2817,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -1994,6 +2878,30 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2097,6 +3005,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -2121,6 +3036,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -2137,6 +3062,14 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -2197,7 +3130,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2230,7 +3162,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2264,6 +3195,193 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
+      "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.11",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
+      "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.1",
+        "@vitest/mocker": "4.1.1",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/runner": "4.1.1",
+        "@vitest/snapshot": "4.1.1",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.1",
+        "@vitest/browser-preview": "4.1.1",
+        "@vitest/browser-webdriverio": "4.1.1",
+        "@vitest/ui": "4.1.1",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build:dashboard": "cd dashboard && npm install && npm run build",
     "dev": "tsx src/index.ts",
     "lint": "tsc --noEmit",
-    "test": "echo \"No tests yet\""
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "keywords": [],
   "author": "Gwenaël Magnenat <gwenael.magnenat@marvelous.digital> (https://marvelous.digital/)",
@@ -35,6 +36,7 @@
     "@types/node-cron": "^3.0.11",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.1"
   }
 }

--- a/src/core/__tests__/alerts.test.ts
+++ b/src/core/__tests__/alerts.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeAlerts,
+  summarizeAlerts,
+  sortAlerts,
+  filterAlertsBySince,
+  SEVERITY_ORDER,
+} from "../alerts.js";
+import type { NormalizedAlert } from "../../types.js";
+
+// --- Fixtures ---
+
+function makeGitHubAlert(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 1,
+    state: "open",
+    dependency: {
+      package: { name: "lodash", ecosystem: "npm" },
+      manifest_path: "package-lock.json",
+    },
+    security_advisory: {
+      severity: "high",
+      ghsa_id: "GHSA-1234-5678",
+      cve_id: "CVE-2024-0001",
+      summary: "Prototype pollution in lodash",
+      cvss: { score: 7.5 },
+    },
+    security_vulnerability: {
+      severity: "high",
+      first_patched_version: { identifier: "4.17.21" },
+    },
+    created_at: "2024-01-15T10:00:00Z",
+    updated_at: "2024-02-01T12:00:00Z",
+    dismissed_at: null,
+    fixed_at: null,
+    html_url: "https://github.com/owner/repo/security/dependabot/1",
+    ...overrides,
+  };
+}
+
+function makeNormalizedAlert(
+  overrides: Partial<NormalizedAlert> = {}
+): NormalizedAlert {
+  return {
+    repo: "owner/repo",
+    alertNumber: 1,
+    state: "open",
+    severity: "high",
+    packageName: "lodash",
+    manifestPath: "package-lock.json",
+    ecosystem: "npm",
+    createdAt: "2024-01-15T10:00:00Z",
+    updatedAt: "2024-02-01T12:00:00Z",
+    dismissedAt: null,
+    fixedAt: null,
+    htmlUrl: "https://github.com/owner/repo/security/dependabot/1",
+    ghsaId: "GHSA-1234-5678",
+    cveId: "CVE-2024-0001",
+    advisorySummary: "Prototype pollution in lodash",
+    cvssScore: 7.5,
+    patchedVersion: "4.17.21",
+    rawJson: "{}",
+    ...overrides,
+  };
+}
+
+// --- normalizeAlerts ---
+
+describe("normalizeAlerts", () => {
+  it("normalizes a standard GitHub alert", () => {
+    const raw = makeGitHubAlert();
+    const [result] = normalizeAlerts("owner/repo", [raw]);
+
+    expect(result.repo).toBe("owner/repo");
+    expect(result.alertNumber).toBe(1);
+    expect(result.state).toBe("open");
+    expect(result.severity).toBe("high");
+    expect(result.packageName).toBe("lodash");
+    expect(result.ecosystem).toBe("npm");
+    expect(result.ghsaId).toBe("GHSA-1234-5678");
+    expect(result.cveId).toBe("CVE-2024-0001");
+    expect(result.cvssScore).toBe(7.5);
+    expect(result.patchedVersion).toBe("4.17.21");
+    expect(result.advisorySummary).toBe("Prototype pollution in lodash");
+  });
+
+  it("falls back to security_vulnerability severity when advisory is missing", () => {
+    const raw = makeGitHubAlert({
+      security_advisory: undefined,
+    });
+    const [result] = normalizeAlerts("owner/repo", [raw]);
+    expect(result.severity).toBe("high");
+  });
+
+  it("defaults severity to 'unknown' when both sources are missing", () => {
+    const raw = makeGitHubAlert({
+      security_advisory: undefined,
+      security_vulnerability: undefined,
+    });
+    const [result] = normalizeAlerts("owner/repo", [raw]);
+    expect(result.severity).toBe("unknown");
+  });
+
+  it("handles null/undefined fields gracefully", () => {
+    const [result] = normalizeAlerts("owner/repo", [{}]);
+    expect(result.alertNumber).toBe(0);
+    expect(result.state).toBe("unknown");
+    expect(result.severity).toBe("unknown");
+    expect(result.packageName).toBeNull();
+    expect(result.ecosystem).toBeNull();
+    expect(result.cvssScore).toBeNull();
+  });
+
+  it("handles non-numeric cvss score", () => {
+    const raw = makeGitHubAlert({
+      security_advisory: {
+        severity: "high",
+        cvss: { score: "not-a-number" },
+      },
+    });
+    const [result] = normalizeAlerts("owner/repo", [raw]);
+    expect(result.cvssScore).toBeNull();
+  });
+
+  it("normalizes multiple alerts", () => {
+    const alerts = [
+      makeGitHubAlert({ number: 1 }),
+      makeGitHubAlert({ number: 2 }),
+      makeGitHubAlert({ number: 3 }),
+    ];
+    const results = normalizeAlerts("owner/repo", alerts);
+    expect(results).toHaveLength(3);
+    expect(results.map((r) => r.alertNumber)).toEqual([1, 2, 3]);
+  });
+
+  it("stores raw JSON", () => {
+    const raw = makeGitHubAlert();
+    const [result] = normalizeAlerts("owner/repo", [raw]);
+    const parsed = JSON.parse(result.rawJson);
+    expect(parsed.number).toBe(1);
+  });
+});
+
+// --- summarizeAlerts ---
+
+describe("summarizeAlerts", () => {
+  it("counts alerts by severity", () => {
+    const alerts = [
+      makeNormalizedAlert({ severity: "critical" }),
+      makeNormalizedAlert({ severity: "high" }),
+      makeNormalizedAlert({ severity: "high" }),
+      makeNormalizedAlert({ severity: "medium" }),
+    ];
+    const counts = summarizeAlerts(alerts);
+    expect(counts).toEqual({ critical: 1, high: 2, medium: 1 });
+  });
+
+  it("returns empty object for no alerts", () => {
+    expect(summarizeAlerts([])).toEqual({});
+  });
+
+  it("lowercases severity keys", () => {
+    const alerts = [makeNormalizedAlert({ severity: "HIGH" })];
+    const counts = summarizeAlerts(alerts);
+    expect(counts).toHaveProperty("high", 1);
+  });
+});
+
+// --- sortAlerts ---
+
+describe("sortAlerts", () => {
+  it("sorts by severity order (critical first)", () => {
+    const alerts = [
+      makeNormalizedAlert({ severity: "low" }),
+      makeNormalizedAlert({ severity: "critical" }),
+      makeNormalizedAlert({ severity: "medium" }),
+      makeNormalizedAlert({ severity: "high" }),
+    ];
+    const sorted = sortAlerts(alerts);
+    expect(sorted.map((a) => a.severity)).toEqual([
+      "critical",
+      "high",
+      "medium",
+      "low",
+    ]);
+  });
+
+  it("sorts by createdAt descending within same severity", () => {
+    const alerts = [
+      makeNormalizedAlert({
+        severity: "high",
+        createdAt: "2024-01-01T00:00:00Z",
+      }),
+      makeNormalizedAlert({
+        severity: "high",
+        createdAt: "2024-03-01T00:00:00Z",
+      }),
+      makeNormalizedAlert({
+        severity: "high",
+        createdAt: "2024-02-01T00:00:00Z",
+      }),
+    ];
+    const sorted = sortAlerts(alerts);
+    expect(sorted.map((a) => a.createdAt)).toEqual([
+      "2024-03-01T00:00:00Z",
+      "2024-02-01T00:00:00Z",
+      "2024-01-01T00:00:00Z",
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    const alerts = [
+      makeNormalizedAlert({ severity: "low" }),
+      makeNormalizedAlert({ severity: "critical" }),
+    ];
+    const original = [...alerts];
+    sortAlerts(alerts);
+    expect(alerts[0].severity).toBe(original[0].severity);
+  });
+
+  it("puts unknown severity last", () => {
+    const alerts = [
+      makeNormalizedAlert({ severity: "unknown" }),
+      makeNormalizedAlert({ severity: "low" }),
+    ];
+    const sorted = sortAlerts(alerts);
+    expect(sorted.map((a) => a.severity)).toEqual(["low", "unknown"]);
+  });
+});
+
+// --- filterAlertsBySince ---
+
+describe("filterAlertsBySince", () => {
+  it("returns all alerts when since is null", () => {
+    const alerts = [makeNormalizedAlert(), makeNormalizedAlert()];
+    expect(filterAlertsBySince(alerts, null)).toHaveLength(2);
+  });
+
+  it("filters alerts before the since date", () => {
+    const alerts = [
+      makeNormalizedAlert({ updatedAt: "2024-01-01T00:00:00Z" }),
+      makeNormalizedAlert({ updatedAt: "2024-06-01T00:00:00Z" }),
+    ];
+    const since = new Date("2024-03-01");
+    const filtered = filterAlertsBySince(alerts, since);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].updatedAt).toBe("2024-06-01T00:00:00Z");
+  });
+
+  it("uses createdAt as fallback when updatedAt is null", () => {
+    const alerts = [
+      makeNormalizedAlert({
+        updatedAt: null,
+        createdAt: "2024-06-01T00:00:00Z",
+      }),
+    ];
+    const since = new Date("2024-03-01");
+    expect(filterAlertsBySince(alerts, since)).toHaveLength(1);
+  });
+
+  it("excludes alerts with no timestamp", () => {
+    const alerts = [
+      makeNormalizedAlert({ updatedAt: null, createdAt: null }),
+    ];
+    const since = new Date("2024-01-01");
+    expect(filterAlertsBySince(alerts, since)).toHaveLength(0);
+  });
+
+  it("excludes alerts with invalid date strings", () => {
+    const alerts = [
+      makeNormalizedAlert({ updatedAt: "not-a-date", createdAt: null }),
+    ];
+    const since = new Date("2024-01-01");
+    expect(filterAlertsBySince(alerts, since)).toHaveLength(0);
+  });
+});
+
+// --- SEVERITY_ORDER ---
+
+describe("SEVERITY_ORDER", () => {
+  it("lists severities from most to least critical", () => {
+    expect(SEVERITY_ORDER).toEqual([
+      "critical",
+      "high",
+      "medium",
+      "low",
+      "unknown",
+    ]);
+  });
+});

--- a/src/core/__tests__/db-helpers.test.ts
+++ b/src/core/__tests__/db-helpers.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import {
+  snakeToCamel,
+  camelToSnake,
+  mapRow,
+  buildUpsert,
+  buildInsert,
+  runMigrations,
+  type Migration,
+} from "../db-helpers.js";
+import Database from "better-sqlite3";
+
+// --- Case conversion ---
+
+describe("snakeToCamel", () => {
+  it("converts snake_case to camelCase", () => {
+    expect(snakeToCamel("alert_number")).toBe("alertNumber");
+    expect(snakeToCamel("created_at")).toBe("createdAt");
+    expect(snakeToCamel("html_url")).toBe("htmlUrl");
+  });
+
+  it("handles multiple underscores", () => {
+    expect(snakeToCamel("first_patched_version")).toBe("firstPatchedVersion");
+  });
+
+  it("handles strings with no underscores", () => {
+    expect(snakeToCamel("repo")).toBe("repo");
+  });
+
+  it("handles numeric segments", () => {
+    expect(snakeToCamel("version_2_name")).toBe("version2Name");
+  });
+});
+
+describe("camelToSnake", () => {
+  it("converts camelCase to snake_case", () => {
+    expect(camelToSnake("alertNumber")).toBe("alert_number");
+    expect(camelToSnake("createdAt")).toBe("created_at");
+    expect(camelToSnake("htmlUrl")).toBe("html_url");
+  });
+
+  it("handles strings with no uppercase", () => {
+    expect(camelToSnake("repo")).toBe("repo");
+  });
+});
+
+describe("mapRow", () => {
+  it("maps snake_case keys to camelCase", () => {
+    const row = { alert_number: 1, created_at: "2024-01-01", repo: "foo/bar" };
+    expect(mapRow(row)).toEqual({
+      alertNumber: 1,
+      createdAt: "2024-01-01",
+      repo: "foo/bar",
+    });
+  });
+});
+
+// --- SQL generation ---
+
+describe("buildUpsert", () => {
+  it("generates correct upsert SQL", () => {
+    const sql = buildUpsert(
+      "alerts",
+      ["repo", "alertNumber", "state"],
+      ["repo", "alertNumber"]
+    );
+    expect(sql).toContain("INSERT INTO alerts");
+    expect(sql).toContain("repo, alert_number, state");
+    expect(sql).toContain("@repo, @alertNumber, @state");
+    expect(sql).toContain("ON CONFLICT(repo, alert_number)");
+    expect(sql).toContain("state = excluded.state");
+    // Conflict keys should not appear in the UPDATE SET clause
+    expect(sql).not.toContain("repo = excluded.repo");
+  });
+});
+
+describe("buildInsert", () => {
+  it("generates correct insert SQL", () => {
+    const sql = buildInsert("alert_history", ["repo", "alertNumber", "state"]);
+    expect(sql).toContain("INSERT INTO alert_history");
+    expect(sql).toContain("repo, alert_number, state");
+    expect(sql).toContain("@repo, @alertNumber, @state");
+  });
+});
+
+// --- Migration runner ---
+
+describe("runMigrations", () => {
+  it("runs pending migrations in version order", () => {
+    const db = new Database(":memory:");
+    const order: number[] = [];
+
+    const migrations: Migration[] = [
+      { version: 3, up: () => order.push(3) },
+      { version: 1, up: () => order.push(1) },
+      { version: 2, up: () => order.push(2) },
+    ];
+
+    runMigrations(db, migrations);
+    expect(order).toEqual([1, 2, 3]);
+
+    db.close();
+  });
+
+  it("skips already-applied migrations", () => {
+    const db = new Database(":memory:");
+    const order: number[] = [];
+
+    const migrations: Migration[] = [
+      { version: 1, up: () => order.push(1) },
+      { version: 2, up: () => order.push(2) },
+    ];
+
+    runMigrations(db, migrations);
+    expect(order).toEqual([1, 2]);
+
+    // Run again — nothing should execute
+    order.length = 0;
+    runMigrations(db, migrations);
+    expect(order).toEqual([]);
+
+    db.close();
+  });
+
+  it("only runs new migrations after existing version", () => {
+    const db = new Database(":memory:");
+    const order: number[] = [];
+
+    runMigrations(db, [{ version: 1, up: () => order.push(1) }]);
+    expect(order).toEqual([1]);
+
+    order.length = 0;
+    runMigrations(db, [
+      { version: 1, up: () => order.push(1) },
+      { version: 2, up: () => order.push(2) },
+      { version: 3, up: () => order.push(3) },
+    ]);
+    expect(order).toEqual([2, 3]);
+
+    db.close();
+  });
+
+  it("tracks schema version in _meta table", () => {
+    const db = new Database(":memory:");
+
+    runMigrations(db, [
+      { version: 1, up: () => {} },
+      { version: 2, up: () => {} },
+    ]);
+
+    const row = db
+      .prepare("SELECT value FROM _meta WHERE key = 'schema_version'")
+      .get() as { value: string };
+    expect(row.value).toBe("2");
+
+    db.close();
+  });
+});

--- a/src/core/__tests__/db.test.ts
+++ b/src/core/__tests__/db.test.ts
@@ -1,0 +1,555 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  openDatabase,
+  saveAlerts,
+  getCachedAlerts,
+  getGlobalSummary,
+  getAllRepoSummaries,
+  getRepoAlerts,
+  getTrendData,
+  getMttrMetrics,
+  getSlaViolations,
+  getVulnerabilityGroups,
+  getDependencyLandscape,
+  getEcosystemBreakdown,
+  getAlertTimeline,
+  clearDatabase,
+  removeRepo,
+} from "../db.js";
+import type { NormalizedAlert } from "../../types.js";
+
+// --- Helpers ---
+
+function makeAlert(overrides: Partial<NormalizedAlert> = {}): NormalizedAlert {
+  return {
+    repo: "owner/repo",
+    alertNumber: 1,
+    state: "open",
+    severity: "high",
+    packageName: "lodash",
+    manifestPath: "package-lock.json",
+    ecosystem: "npm",
+    createdAt: "2024-01-15T10:00:00Z",
+    updatedAt: "2024-02-01T12:00:00Z",
+    dismissedAt: null,
+    fixedAt: null,
+    htmlUrl: "https://github.com/owner/repo/security/dependabot/1",
+    ghsaId: "GHSA-1234-5678",
+    cveId: "CVE-2024-0001",
+    advisorySummary: "Prototype pollution in lodash",
+    cvssScore: 7.5,
+    patchedVersion: "4.17.21",
+    rawJson: JSON.stringify({ number: 1 }),
+    ...overrides,
+  };
+}
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = openDatabase(":memory:");
+});
+
+afterEach(() => {
+  db.close();
+});
+
+// --- saveAlerts & getCachedAlerts ---
+
+describe("saveAlerts", () => {
+  it("saves and retrieves alerts", () => {
+    const alerts = [
+      makeAlert({ alertNumber: 1 }),
+      makeAlert({ alertNumber: 2, severity: "critical" }),
+    ];
+    saveAlerts(db, "owner/repo", alerts, "2024-03-01T00:00:00Z");
+
+    const cached = getCachedAlerts(db, "owner/repo");
+    expect(cached.hasCache).toBe(true);
+    expect(cached.lastSync).toBe("2024-03-01T00:00:00Z");
+    expect(cached.alerts).toHaveLength(2);
+  });
+
+  it("returns no cache for unknown repos", () => {
+    const cached = getCachedAlerts(db, "unknown/repo");
+    expect(cached.hasCache).toBe(false);
+    expect(cached.alerts).toHaveLength(0);
+    expect(cached.lastSync).toBeNull();
+  });
+
+  it("upserts alerts on re-save", () => {
+    const alert = makeAlert({ state: "open" });
+    saveAlerts(db, "owner/repo", [alert], "2024-03-01T00:00:00Z");
+
+    const updated = makeAlert({ state: "fixed" });
+    saveAlerts(db, "owner/repo", [updated], "2024-03-02T00:00:00Z");
+
+    const cached = getCachedAlerts(db, "owner/repo");
+    expect(cached.alerts).toHaveLength(1);
+    expect(cached.alerts[0].state).toBe("fixed");
+    expect(cached.lastSync).toBe("2024-03-02T00:00:00Z");
+  });
+
+  it("records history only on state changes", () => {
+    const alert = makeAlert({ state: "open" });
+    saveAlerts(db, "owner/repo", [alert], "2024-03-01T00:00:00Z");
+
+    // Save again with same state — no new history
+    saveAlerts(db, "owner/repo", [alert], "2024-03-02T00:00:00Z");
+
+    const historyCount = (
+      db
+        .prepare("SELECT COUNT(*) AS cnt FROM alert_history WHERE repo = ?")
+        .get("owner/repo") as { cnt: number }
+    ).cnt;
+
+    // First save always creates a history entry (new alert), second save should not
+    expect(historyCount).toBe(1);
+  });
+
+  it("records history when state changes", () => {
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ state: "open" })],
+      "2024-03-01T00:00:00Z"
+    );
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ state: "fixed" })],
+      "2024-03-02T00:00:00Z"
+    );
+
+    const historyCount = (
+      db
+        .prepare("SELECT COUNT(*) AS cnt FROM alert_history WHERE repo = ?")
+        .get("owner/repo") as { cnt: number }
+    ).cnt;
+    expect(historyCount).toBe(2); // open + fixed
+  });
+
+  it("records history when severity changes", () => {
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ severity: "high" })],
+      "2024-03-01T00:00:00Z"
+    );
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ severity: "critical" })],
+      "2024-03-02T00:00:00Z"
+    );
+
+    const historyCount = (
+      db
+        .prepare("SELECT COUNT(*) AS cnt FROM alert_history WHERE repo = ?")
+        .get("owner/repo") as { cnt: number }
+    ).cnt;
+    expect(historyCount).toBe(2);
+  });
+});
+
+// --- getRepoAlerts ---
+
+describe("getRepoAlerts", () => {
+  it("returns sorted alerts", () => {
+    const alerts = [
+      makeAlert({ alertNumber: 1, severity: "low" }),
+      makeAlert({ alertNumber: 2, severity: "critical" }),
+      makeAlert({ alertNumber: 3, severity: "high" }),
+    ];
+    saveAlerts(db, "owner/repo", alerts, "2024-03-01T00:00:00Z");
+
+    const { alerts: sorted } = getRepoAlerts(db, "owner/repo");
+    expect(sorted.map((a) => a.severity)).toEqual(["critical", "high", "low"]);
+  });
+});
+
+// --- getGlobalSummary ---
+
+describe("getGlobalSummary", () => {
+  it("returns totals across all repos", () => {
+    saveAlerts(
+      db,
+      "owner/repo-a",
+      [
+        makeAlert({ repo: "owner/repo-a", alertNumber: 1, severity: "critical" }),
+        makeAlert({ repo: "owner/repo-a", alertNumber: 2, severity: "high" }),
+      ],
+      "2024-03-01T00:00:00Z"
+    );
+    saveAlerts(
+      db,
+      "owner/repo-b",
+      [makeAlert({ repo: "owner/repo-b", alertNumber: 1, severity: "high" })],
+      "2024-03-01T00:00:00Z"
+    );
+
+    const summary = getGlobalSummary(db);
+    expect(summary.totalRepos).toBe(2);
+    expect(summary.totalAlerts).toBe(3);
+    expect(summary.severityCounts.critical).toBe(1);
+    expect(summary.severityCounts.high).toBe(2);
+  });
+
+  it("handles empty database", () => {
+    const summary = getGlobalSummary(db);
+    expect(summary.totalRepos).toBe(0);
+    expect(summary.totalAlerts).toBe(0);
+    expect(summary.severityCounts).toEqual({});
+  });
+});
+
+// --- getAllRepoSummaries ---
+
+describe("getAllRepoSummaries", () => {
+  it("returns per-repo breakdowns", () => {
+    saveAlerts(
+      db,
+      "owner/repo-a",
+      [
+        makeAlert({ repo: "owner/repo-a", alertNumber: 1, severity: "critical" }),
+        makeAlert({ repo: "owner/repo-a", alertNumber: 2, severity: "high" }),
+      ],
+      "2024-03-01T00:00:00Z"
+    );
+    saveAlerts(
+      db,
+      "owner/repo-b",
+      [makeAlert({ repo: "owner/repo-b", alertNumber: 1, severity: "medium" })],
+      "2024-03-01T00:00:00Z"
+    );
+
+    const summaries = getAllRepoSummaries(db);
+    expect(summaries).toHaveLength(2);
+
+    const repoA = summaries.find((s) => s.repo === "owner/repo-a");
+    expect(repoA?.totalAlerts).toBe(2);
+    expect(repoA?.severityCounts.critical).toBe(1);
+
+    const repoB = summaries.find((s) => s.repo === "owner/repo-b");
+    expect(repoB?.totalAlerts).toBe(1);
+    expect(repoB?.severityCounts.medium).toBe(1);
+  });
+
+  it("includes repos with no open alerts", () => {
+    saveAlerts(
+      db,
+      "owner/clean-repo",
+      [makeAlert({ repo: "owner/clean-repo", alertNumber: 1, state: "fixed" })],
+      "2024-03-01T00:00:00Z"
+    );
+
+    const summaries = getAllRepoSummaries(db);
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].totalAlerts).toBe(0);
+  });
+});
+
+// --- getTrendData ---
+
+describe("getTrendData", () => {
+  it("returns daily severity counts from history", () => {
+    saveAlerts(
+      db,
+      "owner/repo",
+      [
+        makeAlert({ alertNumber: 1, severity: "critical" }),
+        makeAlert({ alertNumber: 2, severity: "high" }),
+      ],
+      "2024-03-01T00:00:00Z"
+    );
+
+    const trends = getTrendData(db);
+    expect(trends.length).toBeGreaterThanOrEqual(1);
+    expect(trends[0]).toHaveProperty("day");
+    expect(trends[0]).toHaveProperty("critical");
+    expect(trends[0]).toHaveProperty("high");
+  });
+
+  it("filters by repo when specified", () => {
+    saveAlerts(
+      db,
+      "owner/repo-a",
+      [makeAlert({ repo: "owner/repo-a", alertNumber: 1, severity: "critical" })],
+      "2024-03-01T00:00:00Z"
+    );
+    saveAlerts(
+      db,
+      "owner/repo-b",
+      [makeAlert({ repo: "owner/repo-b", alertNumber: 1, severity: "high" })],
+      "2024-03-01T00:00:00Z"
+    );
+
+    const trends = getTrendData(db, "owner/repo-a");
+    // Should only have critical (from repo-a), not high (from repo-b)
+    for (const point of trends) {
+      expect(point.high).toBe(0);
+    }
+  });
+});
+
+// --- getMttrMetrics ---
+
+describe("getMttrMetrics", () => {
+  it("computes MTTR for resolved alerts", () => {
+    // Create open alert
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ alertNumber: 1, state: "open", severity: "high" })],
+      "2024-01-01T00:00:00Z"
+    );
+    // Resolve it 10 days later
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ alertNumber: 1, state: "fixed", severity: "high" })],
+      "2024-01-11T00:00:00Z"
+    );
+
+    const metrics = getMttrMetrics(db);
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0].repo).toBe("owner/repo");
+    expect(metrics[0].severity).toBe("high");
+    expect(metrics[0].avgDays).toBe(10);
+    expect(metrics[0].resolvedCount).toBe(1);
+  });
+
+  it("returns empty for no resolved alerts", () => {
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ alertNumber: 1, state: "open" })],
+      "2024-01-01T00:00:00Z"
+    );
+
+    const metrics = getMttrMetrics(db);
+    expect(metrics).toHaveLength(0);
+  });
+});
+
+// --- getSlaViolations ---
+
+describe("getSlaViolations", () => {
+  it("flags overdue alerts based on SLA thresholds", () => {
+    // Insert an alert opened long ago
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ alertNumber: 1, severity: "critical" })],
+      "2023-01-01T00:00:00Z"
+    );
+
+    const violations = getSlaViolations(db);
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+
+    const v = violations[0];
+    expect(v.severity).toBe("critical");
+    expect(v.slaLimitDays).toBe(2); // critical default
+    expect(v.overdue).toBe(true);
+    expect(v.openDays).toBeGreaterThan(2);
+  });
+
+  it("respects custom SLA config", () => {
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ alertNumber: 1, severity: "low" })],
+      "2024-12-01T00:00:00Z"
+    );
+
+    // With a very generous SLA, should not be overdue
+    const violations = getSlaViolations(db, { low: 99999 });
+    const v = violations.find((x) => x.alertNumber === 1);
+    expect(v?.overdue).toBe(false);
+  });
+
+  it("returns empty when no open alerts exist", () => {
+    const violations = getSlaViolations(db);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("sorts most overdue first", () => {
+    saveAlerts(
+      db,
+      "owner/repo",
+      [
+        makeAlert({ alertNumber: 1, severity: "low" }), // 90-day SLA
+        makeAlert({ alertNumber: 2, severity: "critical" }), // 2-day SLA
+      ],
+      "2023-06-01T00:00:00Z"
+    );
+
+    const violations = getSlaViolations(db);
+    // Critical with 2-day SLA should be more overdue than low with 90-day SLA
+    expect(violations[0].severity).toBe("critical");
+  });
+});
+
+// --- getAlertTimeline ---
+
+describe("getAlertTimeline", () => {
+  it("returns ordered history entries", () => {
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ alertNumber: 1, state: "open" })],
+      "2024-01-01T00:00:00Z"
+    );
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert({ alertNumber: 1, state: "fixed" })],
+      "2024-01-10T00:00:00Z"
+    );
+
+    const timeline = getAlertTimeline(db, "owner/repo");
+    expect(timeline).toHaveLength(2);
+    expect(timeline[0].state).toBe("open");
+    expect(timeline[1].state).toBe("fixed");
+  });
+});
+
+// --- getVulnerabilityGroups ---
+
+describe("getVulnerabilityGroups", () => {
+  it("groups alerts by GHSA ID", () => {
+    saveAlerts(
+      db,
+      "owner/repo-a",
+      [makeAlert({ repo: "owner/repo-a", alertNumber: 1, ghsaId: "GHSA-0001" })],
+      "2024-03-01T00:00:00Z"
+    );
+    saveAlerts(
+      db,
+      "owner/repo-b",
+      [makeAlert({ repo: "owner/repo-b", alertNumber: 1, ghsaId: "GHSA-0001" })],
+      "2024-03-01T00:00:00Z"
+    );
+
+    const groups = getVulnerabilityGroups(db);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].ghsaId).toBe("GHSA-0001");
+    expect(groups[0].affectedRepos).toBe(2);
+    expect(groups[0].totalAlerts).toBe(2);
+    expect(groups[0].repos).toContain("owner/repo-a");
+    expect(groups[0].repos).toContain("owner/repo-b");
+  });
+});
+
+// --- getDependencyLandscape ---
+
+describe("getDependencyLandscape", () => {
+  it("groups alerts by package name", () => {
+    saveAlerts(
+      db,
+      "owner/repo-a",
+      [
+        makeAlert({
+          repo: "owner/repo-a",
+          alertNumber: 1,
+          packageName: "lodash",
+          severity: "critical",
+        }),
+      ],
+      "2024-03-01T00:00:00Z"
+    );
+    saveAlerts(
+      db,
+      "owner/repo-b",
+      [
+        makeAlert({
+          repo: "owner/repo-b",
+          alertNumber: 1,
+          packageName: "lodash",
+          severity: "high",
+        }),
+      ],
+      "2024-03-01T00:00:00Z"
+    );
+
+    const deps = getDependencyLandscape(db);
+    expect(deps).toHaveLength(1);
+    expect(deps[0].packageName).toBe("lodash");
+    expect(deps[0].affectedRepos).toBe(2);
+    expect(deps[0].criticalCount).toBe(1);
+    expect(deps[0].highCount).toBe(1);
+  });
+});
+
+// --- getEcosystemBreakdown ---
+
+describe("getEcosystemBreakdown", () => {
+  it("counts by ecosystem", () => {
+    saveAlerts(
+      db,
+      "owner/repo",
+      [
+        makeAlert({ alertNumber: 1, ecosystem: "npm" }),
+        makeAlert({ alertNumber: 2, ecosystem: "npm" }),
+        makeAlert({ alertNumber: 3, ecosystem: "pip" }),
+      ],
+      "2024-03-01T00:00:00Z"
+    );
+
+    const eco = getEcosystemBreakdown(db);
+    expect(eco).toHaveLength(2);
+
+    const npm = eco.find((e) => e.ecosystem === "npm");
+    expect(npm?.totalAlerts).toBe(2);
+
+    const pip = eco.find((e) => e.ecosystem === "pip");
+    expect(pip?.totalAlerts).toBe(1);
+  });
+});
+
+// --- clearDatabase ---
+
+describe("clearDatabase", () => {
+  it("removes all data but keeps schema", () => {
+    saveAlerts(
+      db,
+      "owner/repo",
+      [makeAlert()],
+      "2024-03-01T00:00:00Z"
+    );
+    clearDatabase(db);
+
+    const cached = getCachedAlerts(db, "owner/repo");
+    expect(cached.hasCache).toBe(false);
+    expect(cached.alerts).toHaveLength(0);
+
+    // Schema still works — can save again
+    saveAlerts(db, "owner/repo", [makeAlert()], "2024-03-02T00:00:00Z");
+    expect(getCachedAlerts(db, "owner/repo").hasCache).toBe(true);
+  });
+});
+
+// --- removeRepo ---
+
+describe("removeRepo", () => {
+  it("removes only the specified repo", () => {
+    saveAlerts(
+      db,
+      "owner/repo-a",
+      [makeAlert({ repo: "owner/repo-a", alertNumber: 1 })],
+      "2024-03-01T00:00:00Z"
+    );
+    saveAlerts(
+      db,
+      "owner/repo-b",
+      [makeAlert({ repo: "owner/repo-b", alertNumber: 1 })],
+      "2024-03-01T00:00:00Z"
+    );
+
+    removeRepo(db, "owner/repo-a");
+
+    expect(getCachedAlerts(db, "owner/repo-a").hasCache).toBe(false);
+    expect(getCachedAlerts(db, "owner/repo-b").hasCache).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Vitest as test framework with `npm test` and `npm run test:watch` scripts
- 58 tests across 3 test files covering all core business logic:
  - **alerts.ts**: normalizeAlerts, summarizeAlerts, sortAlerts, filterAlertsBySince
  - **db-helpers.ts**: snakeToCamel/camelToSnake, mapRow, buildUpsert/buildInsert, runMigrations
  - **db.ts**: saveAlerts (upsert + history tracking), getCachedAlerts, getGlobalSummary, getAllRepoSummaries, getRepoAlerts, getTrendData, getMttrMetrics, getSlaViolations, getVulnerabilityGroups, getDependencyLandscape, getEcosystemBreakdown, getAlertTimeline, clearDatabase, removeRepo
- All tests use in-memory SQLite (`:memory:`) — no fixtures, mocks, or external deps needed
- Tests run in ~500ms

Closes #17

## Test plan

- [x] `npm test` passes (58/58)
- [x] No changes to production code
- [x] Tests cover key edge cases: empty data, null fields, state change tracking, cross-repo queries