### PR TITLE
fix: reorder migrations array to sequential v1, v2, v3

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -210,17 +210,6 @@ const migrations: Migration[] = [
     },
   },
   {
-    version: 3,
-    up: (db) => {
-      db.exec(
-        [
-          "CREATE INDEX IF NOT EXISTS idx_alerts_repo_state ON alerts(repo, state);",
-          "CREATE INDEX IF NOT EXISTS idx_history_repo_alert ON alert_history(repo, alert_number, state);",
-        ].join("\n")
-      );
-    },
-  },
-  {
     version: 2,
     up: (db) => {
       const columns = [
@@ -248,6 +237,17 @@ const migrations: Migration[] = [
           "  patched_version = json_extract(raw_json, '$.security_vulnerability.first_patched_version.identifier')",
           "WHERE ghsa_id IS NULL AND raw_json IS NOT NULL",
         ].join(" ")
+      );
+    },
+  },
+  {
+    version: 3,
+    up: (db) => {
+      db.exec(
+        [
+          "CREATE INDEX IF NOT EXISTS idx_alerts_repo_state ON alerts(repo, state);",
+          "CREATE INDEX IF NOT EXISTS idx_history_repo_alert ON alert_history(repo, alert_number, state);",
+        ].join("\n")
       );
     },
   },


### PR DESCRIPTION
## Summary
- Reorders the migrations array in `db.ts` so entries are sequential: v1 → v2 → v3
- Runtime behavior is unchanged (`runMigrations()` sorts by version), but the source order was a readability trap for contributors

## Test plan
- [x] All 64 existing tests pass
- [x] Build succeeds

Closes #16