### PR TITLE
fix: add graceful shutdown handling for SIGTERM/SIGINT

### DIFF
--- a/src/cli/dashboard.ts
+++ b/src/cli/dashboard.ts
@@ -128,12 +128,29 @@ export function registerDashboardCommand(program: Command): void {
 
       });
 
-      process.on('SIGINT', () => {
+      let shuttingDown = false;
+      const shutdown = () => {
+        if (shuttingDown) return;
+        shuttingDown = true;
+
         console.log(chalk.gray('\nShutting down...'));
         stopScheduler();
-        server.close();
-        db.close();
-        process.exit(0);
-      });
+
+        const forceExit = setTimeout(() => {
+          console.warn(chalk.yellow('Shutdown timed out, forcing exit'));
+          db.close();
+          process.exit(1);
+        }, 5000);
+        forceExit.unref();
+
+        server.close(() => {
+          clearTimeout(forceExit);
+          db.close();
+          process.exit(0);
+        });
+      };
+
+      process.on('SIGINT', shutdown);
+      process.on('SIGTERM', shutdown);
     });
 }


### PR DESCRIPTION
## Summary

- Add SIGTERM handler alongside SIGINT so Docker `stop` triggers clean shutdown
- Drain in-flight HTTP requests via `server.close()` callback before closing the DB
- Add 5-second forced-exit timeout to prevent indefinite hangs from SSE streams or keep-alive connections
- Guard against double invocation from rapid Ctrl+C or overlapping signals
- Shutdown order: stop scheduler -> drain HTTP -> close DB -> exit(0)

Closes #24

## Test plan
- [ ] `docker compose stop` cleanly shuts down without SIGKILL
- [ ] Ctrl+C in terminal exits cleanly
- [ ] Double Ctrl+C does not crash
- [ ] SSE bulk refresh in progress during shutdown hits the 5s timeout and exits