### PR TITLE
docs: add fix-plan command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ CLI and dashboard to fetch and monitor Dependabot alerts for GitHub repositories
 - Web dashboard with trend charts, MTTR metrics, SLA tracking, and cross-repo analytics.
 - Automatic daily refresh of all tracked repos via built-in cron scheduler.
 - Interactive API documentation via Swagger UI at `/docs`.
+- Fix plan advisor: grouped fix recommendations by package, severity, and ecosystem.
 - Docker-ready for server deployment.
 
 ## Authentication
@@ -72,6 +73,31 @@ Fetch Dependabot alerts for a repo, user, or organization.
 - `--since <date>`: Filter alerts updated since the specified ISO date (e.g., `2023-01-01`).
 - `--json`: Output the results in JSON format.
 - `--refresh`: Bypass the cache and force a fresh fetch from the GitHub API.
+
+#### `fix-plan`
+
+Show grouped fix recommendations for Dependabot alerts. Groups alerts by package, severity, and ecosystem, and shows the patched version to update to.
+
+**Options:**
+
+- `--repo <owner/name>`: Show fix plan for a specific repo (default: all tracked repos).
+- `--db <path>`: Path to the SQLite database file (default: `~/.gh-monit/gh-monit.db`).
+- `--json`: Output the results in JSON format.
+
+```bash
+# Fix plan for all tracked repos
+gh-monit fix-plan
+
+# Fix plan for a specific repo
+gh-monit fix-plan --repo owner/repo
+
+# JSON output for scripting
+gh-monit fix-plan --repo owner/repo --json
+```
+
+The fix plan is also available in the dashboard:
+- **Repo detail view** — click a repo, then the **Fix Plan** tab
+- **Analytics** — the **Fix Plan** sub-tab shows cross-repo recommendations
 
 #### `dashboard`
 
@@ -177,6 +203,7 @@ The raw OpenAPI 3.0 spec is also served at `/api/openapi.json`, which can be imp
 | Bulk refresh | `POST /api/repos/refresh-all` (SSE stream) |
 | History | `GET /api/history/trends`, `GET /api/history/mttr`, `GET /api/history/sla`, `GET /api/repos/:owner/:name/history` |
 | Analytics | `GET /api/analytics/vulnerabilities`, `GET /api/analytics/dependencies`, `GET /api/analytics/ecosystems` |
+| Fix Advisor | `GET /api/fix-advisor`, `GET /api/repos/:owner/:name/fix-advisor` |
 | Setup | `GET /api/setup/status`, `GET /api/setup/repos`, `POST /api/setup/initialize`, `POST /api/setup/reset` |
 | Scheduler | `GET /api/scheduler` |
 

--- a/src/core/openapi.ts
+++ b/src/core/openapi.ts
@@ -19,6 +19,7 @@ export const openapiSpec = {
     { name: 'History', description: 'Trend, MTTR, SLA and timeline analytics' },
     { name: 'Analytics', description: 'Cross-repo vulnerability and dependency insights' },
     { name: 'Setup', description: 'Initial setup wizard and database reset' },
+    { name: 'Fix Advisor', description: 'Grouped fix recommendations for Dependabot alerts' },
     { name: 'Scheduler', description: 'Background refresh scheduler status' },
   ],
   paths: {
@@ -345,6 +346,46 @@ export const openapiSpec = {
         },
       },
     },
+    '/api/fix-advisor': {
+      get: {
+        tags: ['Fix Advisor'],
+        summary: 'Cross-repo fix plan',
+        description: 'Returns grouped fix recommendations across all tracked repositories. Alerts are grouped by package name and ecosystem, with severity breakdown and patched version info.',
+        operationId: 'getFixAdvisor',
+        responses: {
+          '200': {
+            description: 'Fix advisor response',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/FixAdvisorResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/repos/{owner}/{name}/fix-advisor': {
+      get: {
+        tags: ['Fix Advisor'],
+        summary: 'Repo fix plan',
+        description: 'Returns grouped fix recommendations for a specific repository.',
+        operationId: 'getRepoFixAdvisor',
+        parameters: [
+          { $ref: '#/components/parameters/owner' },
+          { $ref: '#/components/parameters/name' },
+        ],
+        responses: {
+          '200': {
+            description: 'Fix advisor response for the repository',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/FixAdvisorResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
     '/api/setup/status': {
       get: {
         tags: ['Setup'],
@@ -580,6 +621,49 @@ export const openapiSpec = {
           uniquePackages: { type: 'integer' },
         },
         required: ['ecosystem', 'totalAlerts', 'affectedRepos', 'uniquePackages'],
+      },
+      FixActionAlert: {
+        type: 'object',
+        properties: {
+          repo: { type: 'string', description: 'Only present in cross-repo responses' },
+          alertNumber: { type: 'integer' },
+          severity: { type: 'string' },
+          summary: { type: 'string', nullable: true },
+        },
+        required: ['alertNumber', 'severity'],
+      },
+      FixAction: {
+        type: 'object',
+        description: 'A grouped fix recommendation for a single package',
+        properties: {
+          packageName: { type: 'string' },
+          ecosystem: { type: 'string', nullable: true },
+          manifestPaths: { type: 'array', items: { type: 'string' } },
+          scope: { type: 'string', nullable: true },
+          groupSeverity: { type: 'string', enum: ['critical', 'high', 'medium', 'low', 'unknown'] },
+          alertCount: { type: 'integer' },
+          severityBreakdown: { $ref: '#/components/schemas/SeverityCounts' },
+          ghsaIds: { type: 'array', items: { type: 'string' } },
+          cveIds: { type: 'array', items: { type: 'string' } },
+          maxCvssScore: { type: 'number', nullable: true },
+          patchedVersion: { type: 'string', nullable: true },
+          hasFix: { type: 'boolean' },
+          affectedRepos: { type: 'integer', description: 'Only present in cross-repo responses' },
+          repos: { type: 'array', items: { type: 'string' }, description: 'Only present in cross-repo responses' },
+          alerts: { type: 'array', items: { $ref: '#/components/schemas/FixActionAlert' } },
+        },
+        required: ['packageName', 'groupSeverity', 'alertCount', 'hasFix', 'alerts'],
+      },
+      FixAdvisorResponse: {
+        type: 'object',
+        properties: {
+          repo: { type: 'string', description: '"all" for cross-repo, or "owner/name" for single repo' },
+          totalActions: { type: 'integer' },
+          totalAlerts: { type: 'integer' },
+          actions: { type: 'array', items: { $ref: '#/components/schemas/FixAction' }, description: 'Fixable groups sorted by severity' },
+          noFixAvailable: { type: 'array', items: { $ref: '#/components/schemas/FixAction' }, description: 'Groups with no patched version available' },
+        },
+        required: ['repo', 'totalActions', 'totalAlerts', 'actions', 'noFixAvailable'],
       },
       SchedulerStatus: {
         type: 'object',


### PR DESCRIPTION
## Summary
- Adds `fix-plan` CLI command documentation with options and usage examples
- Adds Fix Advisor API endpoints (`GET /api/fix-advisor`, `GET /api/repos/:owner/:name/fix-advisor`) to the endpoint table
- Mentions dashboard integration (Fix Plan tab in repo detail view + Analytics sub-tab)
- Adds fix plan advisor to the Features list

## Test plan
- [x] README renders correctly with new sections