### PR TITLE
feat(dashboard): add --host flag to expose server on LAN

### DIFF
--- a/src/cli/dashboard.ts
+++ b/src/cli/dashboard.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
@@ -18,9 +19,36 @@ const DEFAULT_CRON_SCHEDULE = '0 6 * * *';
 
 type DashboardOptions = {
   port: string;
+  host: string;
   open: boolean;
   db: string;
 };
+
+/**
+ * Returns true if the bind address is a wildcard that accepts any
+ * incoming interface (0.0.0.0 for IPv4, :: for IPv6).
+ */
+function isWildcardHost(host: string): boolean {
+  return host === '0.0.0.0' || host === '::';
+}
+
+/**
+ * Returns the external IPv4 addresses the host is reachable at,
+ * used to print helpful LAN URLs when binding to a wildcard address.
+ */
+function getLanAddresses(): string[] {
+  const nets = os.networkInterfaces();
+  const addresses: string[] = [];
+  for (const ifaces of Object.values(nets)) {
+    if (!ifaces) continue;
+    for (const iface of ifaces) {
+      if (iface.family === 'IPv4' && !iface.internal) {
+        addresses.push(iface.address);
+      }
+    }
+  }
+  return addresses;
+}
 
 /**
  * Resolves the dashboard static directory.
@@ -74,6 +102,11 @@ export function registerDashboardCommand(program: Command): void {
     .command('dashboard')
     .description('Start the web dashboard to browse Dependabot alerts')
     .option('--port <number>', 'Port to listen on', '3847')
+    .option(
+      '--host <address>',
+      'Host/interface to bind to (use 0.0.0.0 to expose on the LAN)',
+      '127.0.0.1'
+    )
     .option('--no-open', 'Skip opening the browser automatically')
     .option('--db <path>', 'Path to sqlite db', DEFAULT_DB_PATH)
     .action((options: DashboardOptions) => {
@@ -106,14 +139,33 @@ export function registerDashboardCommand(program: Command): void {
       }
 
       const app = createServer(db, octokit, dashboardDir);
-      const url = `http://localhost:${port}`;
+      const host = options.host;
+      const wildcard = isWildcardHost(host);
+      // Wildcard binds aren't clickable URLs — use localhost for the
+      // primary display/auto-open, and list LAN addresses separately.
+      const primaryUrl = `http://${wildcard ? 'localhost' : host}:${port}`;
 
       const cronExpression =
         process.env.GH_MONIT_REFRESH_SCHEDULE || DEFAULT_CRON_SCHEDULE;
 
-      const server = serve({ fetch: app.fetch, port }, () => {
+      const server = serve({ fetch: app.fetch, port, hostname: host }, () => {
         console.log(chalk.bold('\n  gh-monit Dashboard\n'));
-        console.log(`  ${chalk.green('➜')}  ${chalk.cyan(url)}\n`);
+        console.log(`  ${chalk.green('➜')}  Local:   ${chalk.cyan(primaryUrl)}`);
+        if (wildcard) {
+          const lan = getLanAddresses();
+          if (lan.length === 0) {
+            console.log(
+              `  ${chalk.green('➜')}  Network: ${chalk.gray('no external interfaces found')}`
+            );
+          } else {
+            for (const addr of lan) {
+              console.log(
+                `  ${chalk.green('➜')}  Network: ${chalk.cyan(`http://${addr}:${port}`)}`
+              );
+            }
+          }
+        }
+        console.log('');
 
         startScheduler(db, octokit, cronExpression);
         console.log(
@@ -123,7 +175,7 @@ export function registerDashboardCommand(program: Command): void {
         console.log(chalk.gray('  Press Ctrl+C to stop\n'));
 
         if (options.open) {
-          openBrowser(url);
+          openBrowser(primaryUrl);
         }
 
       });


### PR DESCRIPTION
## Summary
- Adds `--host <address>` option to the `dashboard` command (default `127.0.0.1`) and passes it through to `@hono/node-server.serve()` as `hostname`.
- When a wildcard address (`0.0.0.0` / `::`) is used, the startup banner lists the host's external IPv4 addresses via `os.networkInterfaces()`, so URLs are copy-pastable into a VM/other machine without hunting for the host IP.
- Default behavior is unchanged — existing users stay bound to loopback only.

## Why
Wanted to open the dev dashboard from a Windows guest running in UTM on the Mac host. The server was previously bound to localhost, so LAN access was impossible even though UTM's shared network gives the guest a clean route to the host at `192.168.64.1`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 100/100 pass
- [x] `dashboard --host 0.0.0.0 --port 3999`: `curl http://127.0.0.1:3999/` → 200, `curl http://192.168.64.1:3999/` → 200, `curl http://192.168.64.1:3999/api/repos` → 200 `[]`
- [x] `dashboard --port 3998` (default host): `curl http://127.0.0.1:3998/` → 200, `curl http://192.168.64.1:3998/` → connection refused (default is still loopback-only)
- [ ] Smoke-test from the actual Windows/UTM guest browser

Refs: td-2e2bce